### PR TITLE
Updated to work with Julia v1.0 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,195 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Arpack]]
+deps = ["Arpack_jll", "Libdl", "LinearAlgebra"]
+git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
+uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+version = "0.4.0"
+
+[[Arpack_jll]]
+deps = ["Libdl", "OpenBLAS_jll", "Pkg"]
+git-tree-sha1 = "e214a9b9bd1b4e1b4f15b22c0994862b66af7ff7"
+uuid = "68821587-b530-5797-8361-c406ea357684"
+version = "3.5.0+3"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "31d0151f5716b655421d9d75b7fa74cc4e744df2"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.39.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.10"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
+
+[[KahanSummation]]
+deps = ["Test"]
+git-tree-sha1 = "1f01068b28d3ad83d4d1212a0ce8d7ecacb33482"
+uuid = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
+version = "0.1.0"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MatrixNetworks]]
+deps = ["Arpack", "DataStructures", "DelimitedFiles", "IterTools", "KahanSummation", "LinearAlgebra", "Printf", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "f6794d987d426bab570aabb2d03e2f40ca4fc438"
+uuid = "4f449596-a032-5618-b826-5a251cb6dc11"
+version = "1.0.2"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NetworkAlign"
 uuid = "0d28ce50-4895-482a-87a2-6d5a801cbd9e"
-authors = ["Charlie <ccolley@purdue.edu>"]
+authors = ["Huda Nassar <hnassar@purdue.edu>"]
 version = "0.1.0"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "NetworkAlign"
+uuid = "0d28ce50-4895-482a-87a2-6d5a801cbd9e"
+authors = ["Charlie <ccolley@purdue.edu>"]
+version = "0.1.0"
+
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+KahanSummation = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MatrixNetworks = "4f449596-a032-5618-b826-5a251cb6dc11"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/NetworkAlign.jl
+++ b/src/NetworkAlign.jl
@@ -2,7 +2,11 @@ module NetworkAlign
 
 using MatrixNetworks
 using SparseArrays
-using Printf
+
+import Printf: @printf
+import DelimitedFiles: readdlm
+import LinearAlgebra: triu, dot, norm, issymmetric
+import KahanSummation: sum_kbn
 
 """
 Module ``NetworkAlign``: Documentation on the module

--- a/src/NetworkAlign.jl
+++ b/src/NetworkAlign.jl
@@ -1,6 +1,8 @@
 module NetworkAlign
 
 using MatrixNetworks
+using SparseArrays
+using Printf
 
 """
 Module ``NetworkAlign``: Documentation on the module
@@ -8,7 +10,7 @@ Module ``NetworkAlign``: Documentation on the module
 You can check the readme file here: \n
 "https://github.com/nassarhuda/NetworkAlign.jl/blob/master/README.md"
 """
-NetworkAlign
+#NetworkAlign
 
 include("normout.jl")
 include("othermaxplus.jl")

--- a/src/column_maxmatchsum.jl
+++ b/src/column_maxmatchsum.jl
@@ -35,9 +35,9 @@ end
 for i  = 2:n
     offset[i] = offset[i-1] + deg[i-1]
 end
-offset += 1
+offset .+= 1
 
-deg[:] = 0
+deg .= 0
 
 for i  = 1:nedges
     list[offset[v1[i]] + deg[v1[i]]] = v2[i]

--- a/src/column_maxmatchsum.jl
+++ b/src/column_maxmatchsum.jl
@@ -1,9 +1,9 @@
-type one_matching_output
+struct one_matching_output
     q::Float64
     mi::Vector{Int64}
 end
 
-type all_matching_output
+struct all_matching_output
     q::Vector{Float64}
     mi::Vector{Int64}
     mj::Vector{Int64}

--- a/src/isorank.jl
+++ b/src/isorank.jl
@@ -2,15 +2,49 @@
 ISORANK
 -------
     solve an overlap matching problem with IsoRank
+    For details: [http://cb.csail.mit.edu/cb/mna/]
+    max  a*w'*x + b/2*x'*S*x
+    Usage
+    ----
+    x,flag,reshist = isorank(S,w,a,b,li,lj)
+    Input:
+    ----
+    - `S`: the complete set of squares
+    - `w`: the matching weights for all edges in the link graph L
+    - `a`: the value of a in the above equation
+    - `b`: the value of b in the above equation
+    - `li`: the start point of each edge in L
+    - `lj`: the end point of each edge in L
+    - `alpha`: same as alpha in the PageRank equation
+    - `rtype`: the rounding type (default 1)
+        * rtype = 1: only consider the current matching
+        * rtype = 2: enrich the matching with info from other squares
+    - `tol`: tolerance value
+    - `maxiter`: maximum number of iterations to take
+    - `verbose`: output at each iterations (default true)
+    Methods:
+    -------
+    x,flag,reshist = isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose)
+    x,flag,reshist = isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit)
+    x,flag,reshist = isorank(S,w,a,b,li,lj,alpha,rtype,tol)
+    x,flag,reshist = isorank(S,w,a,b,li,lj,alpha,rtype)
+    x,flag,reshist = isorank(S,w,a,b,li,lj,alpha)
+    x,flag,reshist = isorank(S,w,a,b,li,lj)
+    Example:
+    -------
+    S,w,li,lj = netalign_setup(A,B,L)
+    a = 0.2
+    b = 0.8
+    x,flag,reshist = isorank(S,w,a,b,li,lj)
+    ma,mb = edge_list(bipartite_matching(x,li,lj))
 """
-
-function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
-                 a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
-                 alpha::Float64,rtype::Int64,tol::Float64,
-                 maxit::Int64,verbose::Bool,P::SparseMatrixCSC{Float64,Int64}) where T
+function isorank(S::SparseMatrixCSC{T,Int},w::Vector{Float64},
+                 a::Q,b::Q,li::Vector{Int},lj::Vector{Int},
+                 alpha::Float64,rtype::Int,tol::Float64,
+                 maxit::Int,verbose::Bool,P::SparseMatrixCSC{R,Int}) where {T,Q,R}
   csum = sum_kbn(w)
   v = w./csum
-  assert(all(v.>=0))
+  @assert all(v.>=0)
   n = size(P,1)
 
   allstats = !isempty(li) && !isempty(lj)
@@ -43,7 +77,7 @@ function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
     y = r * (P' * x)
     omega = sum_kbn(x) - sum_kbn(y)
     y = y + omega * v
-    delta = vecnorm(x-y,1)
+    delta = norm(x-y,1)
     reshist[iter+1] = delta
     iter = iter + 1
     x = y * (1/sum_kbn(y))
@@ -85,6 +119,7 @@ function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   end
   return (x,flag,reshist)
 end
+
 
 function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},

--- a/src/isorank.jl
+++ b/src/isorank.jl
@@ -4,10 +4,10 @@ ISORANK
     solve an overlap matching problem with IsoRank
 """
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
                  alpha::Float64,rtype::Int64,tol::Float64,
-                 maxit::Int64,verbose::Bool,P::SparseMatrixCSC{Float64,Int64})
+                 maxit::Int64,verbose::Bool,P::SparseMatrixCSC{Float64,Int64}) where T
   csum = sum_kbn(w)
   v = w./csum
   assert(all(v.>=0))
@@ -86,28 +86,28 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return (x,flag,reshist)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
                  alpha::Float64,rtype::Int64,tol::Float64,
-                 maxit::Int64,verbose::Bool)
+                 maxit::Int64,verbose::Bool) where T
   ss = sum(S,2)
   P = sparse(S./ss)
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
                  alpha::Float64,rtype::Int64,tol::Float64,
-                 maxit::Int64)
+                 maxit::Int64) where T
   verbose = true
   ss = sum(S,2)
   P = sparse(S./ss)
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
-                 alpha::Float64,rtype::Int64,tol::Float64)
+                 alpha::Float64,rtype::Int64,tol::Float64) where T
   maxit = 100
   verbose = true
   ss = sum(S,2)
@@ -115,9 +115,9 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
-                 alpha::Float64,rtype::Int64)
+                 alpha::Float64,rtype::Int64) where T
   tol = 1e-12
   maxit = 100
   verbose = true
@@ -126,9 +126,9 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
                  a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64},
-                 alpha::Float64)
+                 alpha::Float64) where T
   rtype = 2
   tol = 1e-12
   maxit = 100
@@ -138,8 +138,8 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
-                 a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64})
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+                 a::Int64,b::Int64,li::Vector{Int64},lj::Vector{Int64}) where T
   alpha = b/(a+b)
   rtype = 2
   tol = 1e-12
@@ -149,8 +149,8 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
-                 a::Int64,b::Int64)
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+                 a::Int64,b::Int64) where T
   li = []
   lj = []
   alpha = b/(a+b)
@@ -163,8 +163,8 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
-                 a::Int64)
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
+                 a::Int64) where T
   b = 1
   li = []
   lj = []
@@ -178,7 +178,7 @@ function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64},
   return isorank(S,w,a,b,li,lj,alpha,rtype,tol,maxit,verbose,P)
 end
 
-function isorank{T}(S::SparseMatrixCSC{T,Int64},w::Vector{Float64})
+function isorank(S::SparseMatrixCSC{T,Int64},w::Vector{Float64}) where T
   a = 0.5
   b = 1
   li = []

--- a/src/load_netalign_problem.jl
+++ b/src/load_netalign_problem.jl
@@ -1,9 +1,9 @@
-using MatrixNetworks
+#using MatrixNetworks
 
 function load_netalign_problem(probname)
 
 if probname == "lcsh2wiki-small"
-    mainloc = joinpath(Pkg.dir("NetworkAlign"),"data/lcsh2wiki-small")
+    mainloc = joinpath(dirname(pathof(NetworkAlign)),"../data/lcsh2wiki-small")
     # mainloc = "../data/lcsh2wiki-small"
     location = join([mainloc,"_A.smat"])
     A = MatrixNetworks.readSMAT(location)
@@ -14,8 +14,8 @@ if probname == "lcsh2wiki-small"
     location = join([mainloc,"_L.smat"])
     (rows,header) = readdlm(location;header=true)
     L = sparse(
-               convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1,
-               convert(Array{Int64,1},rows[1:parse(Int,header[3]),2])+1,
+               convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1,
+               convert(Array{Int64,1},rows[1:parse(Int,header[3]),2]).+1,
                rows[1:parse(Int,header[3]),3],
                parse(Int,header[1]),
                parse(Int,header[2])
@@ -27,26 +27,26 @@ if probname == "lcsh2wiki-small"
     location = join([mainloc,"_li.smat"])
     (rows,header) = readdlm(location;header=true)
     li = zeros(Int64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     li[ri] = convert(Array{Int64,1},rows[1:parse(Int,header[3]),3])
 
     location = join([mainloc,"_lj.smat"])
     (rows,header) = readdlm(location;header=true)
     lj = zeros(Int64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     lj[ri] = convert(Array{Int64,1},rows[1:parse(Int,header[3]),3])
 
     location = join([mainloc,"_lw.smat"])
     (rows,header) = readdlm(location;header=true)
     w = zeros(Float64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     w[ri] = rows[1:parse(Int,header[3]),3]
 
     return (S,w,li,lj,A,B,L)
 
 elseif probname == "example-overlap"
 
-    mainloc = joinpath(Pkg.dir("NetworkAlign"),"data/example-overlap")
+    mainloc = joinpath(dirname(pathof(NetworkAlign)),"../data/example-overlap")
     # mainloc = "../data/example-overlap"
     location = join([mainloc,"_A.smat"])
     A = MatrixNetworks.readSMAT(location)
@@ -56,9 +56,10 @@ elseif probname == "example-overlap"
 
     location = join([mainloc,"_L.smat"])
     (rows,header) = readdlm(location;header=true)
+    #println(rows[1:parse(Int,header[3]),1])
     L = sparse(
-               convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1,
-               convert(Array{Int64,1},rows[1:parse(Int,header[3]),2])+1,
+               convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1,
+               convert(Array{Int64,1},rows[1:parse(Int,header[3]),2]).+1,
                rows[1:parse(Int,header[3]),3],
                parse(Int,header[1]),
                parse(Int,header[2])
@@ -70,24 +71,24 @@ elseif probname == "example-overlap"
     location = join([mainloc,"_li.smat"])
     (rows,header) = readdlm(location;header=true)
     li = zeros(Int64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     li[ri] = convert(Array{Int64,1},rows[1:parse(Int,header[3]),3])
 
     location = join([mainloc,"_lj.smat"])
     (rows,header) = readdlm(location;header=true)
     lj = zeros(Int64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     lj[ri] = convert(Array{Int64,1},rows[1:parse(Int,header[3]),3])
 
     location = join([mainloc,"_lw.smat"])
     (rows,header) = readdlm(location;header=true)
     w = zeros(Float64,parse(Int,header[1]))
-    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1])+1
+    ri = convert(Array{Int64,1},rows[1:parse(Int,header[3]),1]).+1
     w[ri] = rows[1:parse(Int,header[3]),3]
 
     return (S,w,li,lj,A,B,L)
 elseif probname == "lcsh2wiki-full"
-  mainloc = joinpath(Pkg.dir("NetworkAlign"),"data",probname)
+  mainloc = joinpath(dirname(pathof(NetworkAlign)),"data",probname)
 
     location = join([mainloc,"_S.smat"])
     S = MatrixNetworks.readSMAT(location)

--- a/src/netalign_setup.jl
+++ b/src/netalign_setup.jl
@@ -1,23 +1,7 @@
 # % NETALIGN_SETUP Setup the data for the netalign codes from the problem data
 
-function netalign_setup(A::SparseMatrixCSC{Int64,Int64},B::SparseMatrixCSC{Int64,Int64},
-                        L::SparseMatrixCSC{Int64,Int64})
-
-undirected = issymmetric(A) && issymmetric(B)
-Se,Le,LeWeights = make_squares(A,B,L,undirected)
-
-li = Le[:,1]
-lj = Le[:,2]
-Se1 = Se[:,1]
-Se2 = Se[:,2]
-S = sparse(Se1,Se2,1,nnz(L),nnz(L))
-
-return (S,LeWeights,li,lj)
-
-end
-
-function netalign_setup(A::SparseMatrixCSC{Int64,Int64},B::SparseMatrixCSC{Int64,Int64},
-                        L::SparseMatrixCSC{Float64,Int64})
+function netalign_setup(A::SparseMatrixCSC{T,Int64},B::SparseMatrixCSC{T,Int64},
+                        L::SparseMatrixCSC{Q,Int64}) where {T,Q}
 
 undirected = issymmetric(A) && issymmetric(B)
 Se,Le,LeWeights = make_squares(A,B,L,undirected)

--- a/src/netalignbp.jl
+++ b/src/netalignbp.jl
@@ -4,10 +4,10 @@ NETALIGNBP
     solve the network alignment problem with Belief Propagation
 """
 
-function netalignbp{T,F,R,K}(S::SparseMatrixCSC{T,Int64},w::Vector{F},
+function netalignbp(S::SparseMatrixCSC{T,Int64},w::Vector{F},
                             a::R,b::K,li::Vector{Int64},
                             lj::Vector{Int64},gam::Float64,
-                            dtype::Int64,maxiter::Int64,verbose::Bool)
+                            dtype::Int64,maxiter::Int64,verbose::Bool) where {T,F,R,K}
   nedges = length(li)
   nsquares = nnz(S)/2
   m = maximum(li)

--- a/src/normout.jl
+++ b/src/normout.jl
@@ -8,13 +8,13 @@ function normout(A::SparseMatrixCSC{T,Int64}) where T
   #
 
   # compute the row-sums/degrees
-#   d = sum(A,2)
-#   d = squeeze(d',1)
-#   id = 1./d
-#   P = spdiagm(id)*A
-#   return P
+  #   d = sum(A,2)
+  #   d = squeeze(d',1)
+  #   id = 1./d
+  #   P = spdiagm(id)*A
+  #   return P
 
-    S = vec(sum(A,2))
+    S = vec(sum(A,dims=2))
     ei,ej,ev = findnz(A)
     m,n = size(A)
     P = sparse(ei,ej,ev./S[ei],m,n)

--- a/src/normout.jl
+++ b/src/normout.jl
@@ -1,4 +1,4 @@
-function normout{T}(A::SparseMatrixCSC{T,Int64})
+function normout(A::SparseMatrixCSC{T,Int64}) where T
   # NORMOUT Normalize the outdegrees of the matrix A.
   #
   # P = normout(A)

--- a/src/othermaxplus.jl
+++ b/src/othermaxplus.jl
@@ -1,5 +1,5 @@
-function othermaxplus{T}(dim::Int64,li::Vector{Int64},lj::Vector{Int64},
-                        lw::Vector{T},m::Int64,n::Int64)
+function othermaxplus(dim::Int64,li::Vector{Int64},lj::Vector{Int64},
+                        lw::Vector{T},m::Int64,n::Int64) where T
   # OTHERMAXPLUS Apply the other-max-plus operator to a sparse matrix
   #
   # The other-max-plus operator applies the max-plus aggegration function

--- a/src/round_messages.jl
+++ b/src/round_messages.jl
@@ -1,10 +1,10 @@
-function round_messages{T,F,R,K}(messages::Vector{Float64},
+function round_messages(messages::Vector{Float64},
                         S::SparseMatrixCSC{T,Int64},w::Vector{F},
                         alpha::R,beta::K,
                         rp::Vector{Int64},ci::Vector{Int64},
                         tripi::Vector{Int64},n::Int64,
                         m::Int64,perm::Vector{Int64},
-                        li::Vector{Int64},lj::Vector{Int64})
+                        li::Vector{Int64},lj::Vector{Int64}) where {T,F,R,K}
   ai = zeros(Float64,length(tripi))
   ai[tripi.>0] = messages[perm]
   M_output = MatrixNetworks.bipartite_matching_primal_dual(rp,ci,ai,m,n)


### PR DESCRIPTION
Had a need for the netalignmr function so I went through and updated the functions in this package to use julia 1.0 notation, so others may use it too.  During the process I found your NetworkAlignment.jl package, but that seemed more experimental than the NetworkAlign package so I kept on with this update. I've copied over the documentation/implementations for the isorank/netalignmr/netalignbp functions, and updated the dependencies + helper functions. 

I tested on the functions in the README, and now they execute. 